### PR TITLE
Rename nodes to conquest-chatterbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1>ComfyUI Chatterbox TTS & Voice Conversion Node</h1>
+<h1>conquest-chatterbox</h1>
 
 <p align="center">
   <img src="./assets/preview.png" alt="ComfyUI-KEEP Workflow Example">
@@ -12,22 +12,22 @@ Custom nodes for ComfyUI that integrate the [Resemble AI Chatterbox](https://git
 
 ## 📢 Features
 
-*   **Chatterbox TTS Node:**
+*   **conquest-chatterbox Node:**
     *   Synthesize speech from text.
     *   Optional voice cloning using an audio prompt.
     *   Adjustable parameters: exaggeration, temperature, CFG weight, seed.
     *   Handles long passages by automatically splitting text into manageable chunks.
-*   **Chatterbox Voice Conversion Node:**
+*   **conquest-chatterbox Node:**
     *   Convert the voice in a source audio file to sound like a target voice.
     *   Uses a target audio file for voice characteristics or defaults to a built-in voice if no target is provided.
 *   **Automatic Model Downloading:** Necessary model files are automatically downloaded from Hugging Face (`ResembleAI/chatterbox`) on first use if not found locally.
 
 
-## 🎭 Chatterbox TTS Demo Samples  
+## 🎭 conquest-chatterbox Demo Samples
 Check the [official demo](https://resemble-ai.github.io/chatterbox_demopage/)
 
 ## Installation
-Via ComfyUI Manager [ComfyUI-ChatterboxTTS](https://registry.comfy.org/publishers/wildai/nodes/ComfyUI-ChatterboxTTS) or by cloning the repo:
+Via ComfyUI Manager [conquest-chatterbox](https://registry.comfy.org/publishers/wildai/nodes/ComfyUI-ChatterboxTTS) or by cloning the repo:
 
 1.  **Clone this repository:**
     ```bash
@@ -56,8 +56,7 @@ Via ComfyUI Manager [ComfyUI-ChatterboxTTS](https://registry.comfy.org/publisher
 
 After installation and restarting ComfyUI:
 
-*   The **"Chatterbox TTS 📢"** node will be available under the `audio/generation` category.
-*   The **"Chatterbox Voice Conversion 🗣️"** node will be available under the `audio/conversion` category.
+*   The **"conquest-chatterbox"** node will be available under the `audio/generation` and `audio/conversion` categories.
 
 Load example workflows from the `workflow-examples/` directory in this repository to get started.
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,16 +1,16 @@
 import os
 import folder_paths
-from .nodes import ChatterboxTTSNode, ChatterboxVCNode
+from .nodes import ConquestChatterboxTTSNode, ConquestChatterboxVCNode
 from .modules.chatterbox_handler import CHATTERBOX_MODEL_SUBDIR, DEFAULT_MODEL_PACK_NAME
 
 NODE_CLASS_MAPPINGS = {
-    "ChatterboxTTS": ChatterboxTTSNode,
-    "ChatterboxVC": ChatterboxVCNode,
+    "ChatterboxTTS": ConquestChatterboxTTSNode,
+    "ChatterboxVC": ConquestChatterboxVCNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "ChatterboxTTS": "Chatterbox TTS 📢",
-    "ChatterboxVC": "Chatterbox Voice Conversion 🗣️",
+    "ChatterboxTTS": "conquest-chatterbox",
+    "ChatterboxVC": "conquest-chatterbox",
 }
 
 # WEB_DIRECTORY = "./js" 

--- a/nodes.py
+++ b/nodes.py
@@ -36,7 +36,7 @@ def _split_text_into_chunks(text, tokenizer, max_tokens=1000):
         chunks.append(current)
     return chunks
 
-class Conquest-ChatterboxTTSNode2:
+class ConquestChatterboxTTSNode:
     @classmethod
     def INPUT_TYPES(cls):
         available_model_packs = get_chatterbox_model_pack_names()
@@ -138,7 +138,7 @@ class Conquest-ChatterboxTTSNode2:
         return ({"waveform": wav_tensor_comfy, "sample_rate": chatterbox_model.sr},)
 
 
-class Conquest2-ChatterboxVCNode:
+class ConquestChatterboxVCNode:
     @classmethod
     def INPUT_TYPES(cls):
         available_model_packs = get_chatterbox_model_pack_names()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ComfyUI-ChatterboxTTS"
+name = "conquest-chatterbox"
 description = "ComfyUI Chatterbox TTS & Voice Conversion Node"
 version = "1.0.1"
 license = {file = "LICENSE"}
@@ -11,5 +11,5 @@ Repository = "https://github.com/wildminder/ComfyUI-Chatterbox"
 
 [tool.comfy]
 PublisherId = "wildai"
-DisplayName = "ComfyUI-ChatterboxTTS"
+DisplayName = "conquest-chatterbox"
 Icon = ""


### PR DESCRIPTION
## Summary
- rename node classes to `ConquestChatterboxTTSNode` and `ConquestChatterboxVCNode`
- update mappings and display names to `conquest-chatterbox`
- rename project in pyproject and README references

## Testing
- `python3 -m py_compile nodes.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6857568dbec4833090e40dff3cb2106f