### PR TITLE
Fix node class exports and parameter name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,11 @@
 import os
 import folder_paths
-from .nodes import ChatterboxTTSNode, ChatterboxVCNode
+from .nodes import ChatterboxTTSExtended, ChatterboxVoiceConversion
 from .modules.chatterbox_handler import CHATTERBOX_MODEL_SUBDIR, DEFAULT_MODEL_PACK_NAME
+
+# Backwards compatibility: old names expected by workflow examples
+ChatterboxTTSNode = ChatterboxTTSExtended
+ChatterboxVCNode  = ChatterboxVoiceConversion
 
 NODE_CLASS_MAPPINGS = {
     "ChatterboxTTS": ChatterboxTTSNode,

--- a/nodes.py
+++ b/nodes.py
@@ -243,14 +243,14 @@ class ChatterboxAudioInsert:
     @classmethod
     def INPUT_TYPES(cls):
         return {"required": {
-            "base_audio"  : ("AUDIO",),
-            "insert_audio": ("AUDIO",),
-            "position_sec": ("FLOAT", {"default": 0.0, "min": 0}),
+            "base_audio"   : ("AUDIO",),
+            "segment_audio": ("AUDIO",),
+            "position_sec" : ("FLOAT", {"default": 0.0, "min": 0}),
         }}
 
-    def insert(self, base_audio, insert_audio, position_sec):
+    def insert(self, base_audio, segment_audio, position_sec):
         base_wav, sr = _to_numpy_mono(base_audio)
-        ins_wav,  sr2 = _to_numpy_mono(insert_audio)
+        ins_wav,  sr2 = _to_numpy_mono(segment_audio)
         if sr != sr2:
             raise ValueError("Sampling rates must match")
         out = insert_audio(base_wav, ins_wav, float(position_sec), sr)


### PR DESCRIPTION
## Summary
- avoid parameter shadowing in `ChatterboxAudioInsert`
- export correct node classes from `__init__.py`

## Testing
- `python -m py_compile __init__.py nodes.py modules/chatterbox_handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857618065c0833085f05e83b17a665c