### PR TITLE
Stabilize Chatterbox nodes and add safety options

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -29,6 +29,11 @@ class ChatterboxTTSNode:
                 "exaggeration": ("FLOAT", {"default": 0.5, "min": 0.25, "max": 2.0, "step": 0.05}),
                 "temperature": ("FLOAT", {"default": 0.8, "min": 0.05, "max": 5.0, "step": 0.05}),
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
+                "min_p": ("FLOAT", {"default": 0.05, "min": 0.0, "max": 0.5, "step": 0.01}),
+                "top_p": ("FLOAT", {"default": 0.8, "min": 0.1, "max": 1.0, "step": 0.05}),
+                "repetition_penalty": ("FLOAT", {"default": 2.0, "min": 1.0, "max": 5.0, "step": 0.1}),
+                "chunk_size": ("INT", {"default": 300, "min": 50, "max": 1000, "step": 10}),
+                "max_retries": ("INT", {"default": 1, "min": 0, "max": 5}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
             },
@@ -43,7 +48,9 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight,
+                   min_p, top_p, repetition_penalty, chunk_size, max_retries,
+                   seed, device, audio_prompt=None):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -91,9 +98,14 @@ class ChatterboxTTSNode:
                 text,
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
+                cfg_weight=cfg_weight,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                min_p=min_p,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                chunk_size=chunk_size,
+                max_retries=max_retries,
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000


### PR DESCRIPTION
## Summary
- manually move T3Cond tensors onto the device
- load TTS weights from `safetensors`
- expose min_p, top_p, repetition_penalty, chunk_size and max_retries in the UI
- add long‑prompt safeguards and min_p filtering
- keep only one model cached per device and drop duplicate seed calls

## Testing
- `python -m py_compile nodes.py modules/chatterbox_handler.py src/chatterbox/vc.py`
- `python -m py_compile src/chatterbox/models/t3/t3.py`
- `python -m py_compile src/chatterbox/tts.py`


------
https://chatgpt.com/codex/tasks/task_e_6857734379108330bd913ebbfc3d1b8d