### PR TITLE
Fix long prompt handling and model loading

### DIFF
--- a/modules/chatterbox_handler.py
+++ b/modules/chatterbox_handler.py
@@ -21,7 +21,7 @@ VC_MODEL_CACHE = {}
 CHATTERBOX_MODEL_SUBDIR = "chatterbox_tts"
 CHATTERBOX_REPO_ID = "ResembleAI/chatterbox"
 
-CHATTERBOX_FILES_TO_DOWNLOAD = ["ve.pt", "t3_cfg.pt", "s3gen.pt", "tokenizer.json", "conds.pt"]
+CHATTERBOX_FILES_TO_DOWNLOAD = ["ve.safetensors", "t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json", "conds.pt"]
 DEFAULT_MODEL_PACK_NAME = "resembleai_default_voice"
 
 def get_chatterbox_model_pack_names():
@@ -79,7 +79,7 @@ def download_chatterbox_model_pack_if_missing(model_pack_name):
     
     all_files_successfully_managed = True
 
-    vc_required_files = ["s3gen.pt", "conds.pt"]
+    vc_required_files = ["s3gen.safetensors", "conds.pt"]
 
     files_to_check = CHATTERBOX_FILES_TO_DOWNLOAD
     
@@ -153,7 +153,7 @@ def load_chatterbox_vc_model(model_pack_name, device_str="cuda"):
     #print(f"ChatterboxVC: Attempting to load VC model pack '{model_pack_name}' from '{ckpt_dir}'.")
 
     if not download_chatterbox_model_pack_if_missing(model_pack_name):
-        vc_min_files = ["s3gen.pt", "conds.pt"]
+        vc_min_files = ["s3gen.safetensors", "conds.pt"]
         for f_name in vc_min_files:
             if not os.path.exists(os.path.join(ckpt_dir, f_name)):
                  print(f"ChatterboxVC: Critical file '{f_name}' for VC is missing from pack '{model_pack_name}' after download attempt. Loading will likely fail.")
@@ -170,7 +170,7 @@ def load_chatterbox_vc_model(model_pack_name, device_str="cuda"):
         model = ChatterboxVC.from_local(ckpt_dir, device=device_str)
     except Exception as e:
         print(f"ChatterboxVC: Error during ChatterboxVC.from_local('{ckpt_dir}', device='{device_str}'): {e}")
-        print(f"ChatterboxVC: Please ensure at least 's3gen.pt' and optionally 'conds.pt' (for default voice) are present in {ckpt_dir} or can be downloaded from {CHATTERBOX_REPO_ID}.")
+        print(f"ChatterboxVC: Please ensure at least 's3gen.safetensors' and optionally 'conds.pt' (for default voice) are present in {ckpt_dir} or can be downloaded from {CHATTERBOX_REPO_ID}.")
         raise
     return model
 
@@ -215,7 +215,6 @@ def set_chatterbox_seed(seed: int):
     
     torch.manual_seed(actual_seed_for_torch_random)
     if torch.cuda.is_available():
-        torch.cuda.manual_seed(actual_seed_for_torch_random)
         torch.cuda.manual_seed_all(actual_seed_for_torch_random)
     random.seed(actual_seed_for_torch_random)
     np.random.seed(actual_seed_for_numpy)

--- a/nodes.py
+++ b/nodes.py
@@ -31,6 +31,10 @@ class ChatterboxTTSNode:
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
+                "chunk_size": ("INT", {"default": 300, "min": 100, "max": 1000, "step": 50}),
+                "max_retries": ("INT", {"default": 1, "min": 0, "max": 5}),
+                "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.05}),
+                "repetition_penalty": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 5.0, "step": 0.1}),
             },
             "optional": {
                 "audio_prompt": ("AUDIO",),
@@ -43,7 +47,8 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device,
+                  chunk_size, max_retries, top_p, repetition_penalty, audio_prompt=None):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -92,8 +97,12 @@ class ChatterboxTTSNode:
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                cfg_weight=cfg_weight,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                chunk_size=chunk_size,
+                max_retries=max_retries,
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -6,6 +6,7 @@ import perth
 import torch.nn.functional as F
 import gc
 from huggingface_hub import hf_hub_download
+from safetensors.torch import load_file
 
 from .models.t3 import T3
 from .models.s3tokenizer import S3_SR, drop_invalid_tokens
@@ -66,6 +67,19 @@ class Conditionals:
         return cls(T3Cond(**kwargs['t3']), kwargs['gen'])
 
 
+def move_conditionals_to_device(conds: Conditionals, device: str) -> Conditionals:
+    """Move tensor fields of `conds` to the specified device."""
+    if conds is None:
+        return None
+    t3 = conds.t3
+    for field, value in t3.__dict__.items():
+        if torch.is_tensor(value):
+            setattr(t3, field, value.to(device=device))
+    conds.t3 = t3
+    conds.gen = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in conds.gen.items()}
+    return conds
+
+
 class ChatterboxTTS:
     ENC_COND_LEN = 6 * S3_SR
     DEC_COND_LEN = 10 * S3GEN_SR
@@ -85,39 +99,40 @@ class ChatterboxTTS:
         ckpt_dir = Path(ckpt_dir)
 
         ve = VoiceEncoder()
-        ve.load_state_dict(torch.load(ckpt_dir / "ve.pt"))
+        map_loc = "cpu" if device in {"cpu", "mps"} else None
+        ve.load_state_dict(load_file(ckpt_dir / "ve.safetensors", device=map_loc))
         ve.to(device).eval()
 
         t3 = T3()
-        t3_state = torch.load(ckpt_dir / "t3_cfg.pt")
+        t3_state = load_file(ckpt_dir / "t3_cfg.safetensors", device=map_loc)
         if "model" in t3_state.keys():
             t3_state = t3_state["model"][0]
         t3.load_state_dict(t3_state)
         t3.to(device).eval()
 
         s3gen = S3Gen()
-        s3gen.load_state_dict(torch.load(ckpt_dir / "s3gen.pt"))
+        s3gen.load_state_dict(load_file(ckpt_dir / "s3gen.safetensors", device=map_loc), strict=False)
         s3gen.to(device).eval()
 
         tokenizer = EnTokenizer(str(ckpt_dir / "tokenizer.json"))
 
         conds = None
         if (builtin_voice := ckpt_dir / "conds.pt").exists():
-            conds = Conditionals.load(builtin_voice).to(device)
+            conds = move_conditionals_to_device(Conditionals.load(builtin_voice, map_location=map_loc), device)
 
         return cls(t3, s3gen, ve, tokenizer, device, conds)
 
     @classmethod
     def from_pretrained(cls, device) -> 'ChatterboxTTS':
-        for f in ["ve.pt", "t3_cfg.pt", "s3gen.pt", "tokenizer.json", "conds.pt"]:
+        for f in ["ve.safetensors", "t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json", "conds.pt"]:
             hf_hub_download(repo_id=REPO_ID, filename=f)
-        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.pt")).parent, device)
+        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.safetensors")).parent, device)
 
     def prepare_conditionals(self, wav_fpath, exaggeration=0.5):
         s3gen_ref_wav, _ = librosa.load(wav_fpath, sr=S3GEN_SR)
         ref_16k_wav = librosa.resample(s3gen_ref_wav, orig_sr=S3GEN_SR, target_sr=S3_SR)
 
-        s3gen_ref_wav = s3gen_ref_wav[:self.DEC_COND_LEN]
+        s3gen_ref_wav = s3gen_ref_wav[: self.DEC_COND_LEN]
         s3gen_ref_dict = self.s3gen.embed_ref(s3gen_ref_wav, S3GEN_SR, device=self.device)
 
         if plen := self.t3.hp.speech_cond_prompt_len:
@@ -125,17 +140,20 @@ class ChatterboxTTS:
             t3_cond_prompt_tokens, _ = s3_tokzr.forward([ref_16k_wav[:self.ENC_COND_LEN]], max_len=plen)
             t3_cond_prompt_tokens = torch.atleast_2d(t3_cond_prompt_tokens).to(self.device)
 
-        ve_embed = torch.from_numpy(self.ve.embeds_from_wavs([ref_16k_wav], sample_rate=S3_SR))
-        ve_embed = ve_embed.mean(axis=0, keepdim=True).to(self.device)
+        ve_embed = torch.from_numpy(self.ve.embeds_from_wavs([ref_16k_wav[: self.ENC_COND_LEN]], sample_rate=S3_SR))
+        ve_embed = ve_embed.mean(axis=0, keepdim=True)
 
-        self.conds = Conditionals(
-            T3Cond(
-                speaker_emb=ve_embed,
-                cond_prompt_speech_tokens=t3_cond_prompt_tokens,
-                emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device),
-            s3gen_ref_dict,
+        t3_cond = T3Cond(
+            speaker_emb=ve_embed,
+            cond_prompt_speech_tokens=t3_cond_prompt_tokens,
+            emotion_adv=exaggeration * torch.ones(1, 1, 1),
         )
+
+        self.conds = move_conditionals_to_device(
+            Conditionals(t3_cond, s3gen_ref_dict),
+            self.device,
+        )
+
 
     def _generate_segment(
         self,
@@ -144,6 +162,9 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
     ):
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration)
@@ -156,7 +177,8 @@ class ChatterboxTTS:
                 speaker_emb=_c.speaker_emb,
                 cond_prompt_speech_tokens=_c.cond_prompt_speech_tokens,
                 emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device)
+            )
+            self.conds = move_conditionals_to_device(self.conds, self.device)
 
         text = punc_norm(text)
         text_tokens = self.tokenizer.text_to_tokens(text).to(self.device)
@@ -173,6 +195,8 @@ class ChatterboxTTS:
                 text_tokens=text_tokens,
                 max_new_tokens=1000,
                 temperature=temperature,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
                 cfg_weight=cfg_weight,
             )[0]
 
@@ -189,6 +213,9 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
         chunk_size: int = 300,
         max_retries: int = 1,
     ):
@@ -201,6 +228,9 @@ class ChatterboxTTS:
                         exaggeration=exaggeration,
                         cfg_weight=cfg_weight,
                         temperature=temperature,
+                        top_p=top_p,
+                        repetition_penalty=repetition_penalty,
+                        min_p=min_p,
                     )
                 except RuntimeError as e:
                     if "out of memory" in str(e).lower() and torch.cuda.is_available():


### PR DESCRIPTION
## Summary
- move dataclass tensors to device with a helper
- load all weights from safetensors
- clamp reference waveforms
- expose generation options in node UI
- remove duplicate CUDA seeding

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857734379108330bd913ebbfc3d1b8d