### PR TITLE
Fix device handling and long prompt support

### DIFF
--- a/modules/chatterbox_handler.py
+++ b/modules/chatterbox_handler.py
@@ -21,7 +21,13 @@ VC_MODEL_CACHE = {}
 CHATTERBOX_MODEL_SUBDIR = "chatterbox_tts"
 CHATTERBOX_REPO_ID = "ResembleAI/chatterbox"
 
-CHATTERBOX_FILES_TO_DOWNLOAD = ["ve.pt", "t3_cfg.pt", "s3gen.pt", "tokenizer.json", "conds.pt"]
+CHATTERBOX_FILES_TO_DOWNLOAD = [
+    "ve.safetensors",
+    "t3_cfg.safetensors",
+    "s3gen.safetensors",
+    "tokenizer.json",
+    "conds.pt",
+]
 DEFAULT_MODEL_PACK_NAME = "resembleai_default_voice"
 
 def get_chatterbox_model_pack_names():
@@ -79,7 +85,7 @@ def download_chatterbox_model_pack_if_missing(model_pack_name):
     
     all_files_successfully_managed = True
 
-    vc_required_files = ["s3gen.pt", "conds.pt"]
+    vc_required_files = ["s3gen.safetensors", "conds.pt"]
 
     files_to_check = CHATTERBOX_FILES_TO_DOWNLOAD
     
@@ -122,26 +128,21 @@ def get_cached_chatterbox_tts_model(model_pack_name, device_str="cuda"):
         model_pack_name = available_packs[0] if available_packs else DEFAULT_MODEL_PACK_NAME
         print(f"ChatterboxTTS: No model pack specified for TTS, using '{model_pack_name}'.")
 
-    cache_key = (model_pack_name, device_str, "tts")
-    current_model = TTS_MODEL_CACHE.get(cache_key)
-    model_device_correct = False
-    if current_model is not None and hasattr(current_model, 'device'):
-        try:
-            if str(current_model.device) == device_str:
-                model_device_correct = True
-        except Exception as e:
-            print(f"ChatterboxTTS: Error checking cached TTS model device: {e}. Will reload.")
-
-    if current_model is not None and model_device_correct:
-        return current_model
-    else:
-        if current_model is not None and not model_device_correct:
-            print(f"ChatterboxTTS: Device mismatch for cached TTS model '{model_pack_name}'. Reloading.")
+    cache_key = device_str
+    entry = TTS_MODEL_CACHE.get(cache_key)
+    if entry is not None:
+        pack_name, current_model = entry
+        if pack_name == model_pack_name and str(current_model.device) == device_str:
+            return current_model
         else:
-            print(f"ChatterboxTTS: TTS Model for '{model_pack_name}' on '{device_str}' not in cache. Loading...")
-        
-        TTS_MODEL_CACHE[cache_key] = load_chatterbox_tts_model(model_pack_name, device_str)
-        return TTS_MODEL_CACHE[cache_key]
+            # Replace model on this device with new pack
+            del TTS_MODEL_CACHE[cache_key]
+    else:
+        print(f"ChatterboxTTS: TTS Model for '{model_pack_name}' on '{device_str}' not in cache. Loading...")
+
+    model = load_chatterbox_tts_model(model_pack_name, device_str)
+    TTS_MODEL_CACHE[cache_key] = (model_pack_name, model)
+    return model
 
 
 def load_chatterbox_vc_model(model_pack_name, device_str="cuda"):
@@ -153,7 +154,7 @@ def load_chatterbox_vc_model(model_pack_name, device_str="cuda"):
     #print(f"ChatterboxVC: Attempting to load VC model pack '{model_pack_name}' from '{ckpt_dir}'.")
 
     if not download_chatterbox_model_pack_if_missing(model_pack_name):
-        vc_min_files = ["s3gen.pt", "conds.pt"]
+        vc_min_files = ["s3gen.safetensors", "conds.pt"]
         for f_name in vc_min_files:
             if not os.path.exists(os.path.join(ckpt_dir, f_name)):
                  print(f"ChatterboxVC: Critical file '{f_name}' for VC is missing from pack '{model_pack_name}' after download attempt. Loading will likely fail.")
@@ -170,7 +171,7 @@ def load_chatterbox_vc_model(model_pack_name, device_str="cuda"):
         model = ChatterboxVC.from_local(ckpt_dir, device=device_str)
     except Exception as e:
         print(f"ChatterboxVC: Error during ChatterboxVC.from_local('{ckpt_dir}', device='{device_str}'): {e}")
-        print(f"ChatterboxVC: Please ensure at least 's3gen.pt' and optionally 'conds.pt' (for default voice) are present in {ckpt_dir} or can be downloaded from {CHATTERBOX_REPO_ID}.")
+        print(f"ChatterboxVC: Please ensure at least 's3gen.safetensors' and optionally 'conds.pt' (for default voice) are present in {ckpt_dir} or can be downloaded from {CHATTERBOX_REPO_ID}.")
         raise
     return model
 
@@ -181,25 +182,20 @@ def get_cached_chatterbox_vc_model(model_pack_name, device_str="cuda"):
         model_pack_name = available_packs[0] if available_packs else DEFAULT_MODEL_PACK_NAME
         print(f"ChatterboxVC: No model pack specified for VC, using '{model_pack_name}'.")
 
-    cache_key = (model_pack_name, device_str, "vc")
-    current_model = VC_MODEL_CACHE.get(cache_key)
-    model_device_correct = False
-    if current_model is not None and hasattr(current_model, 'device'):
-        try:
-            if str(current_model.device) == device_str:
-                model_device_correct = True
-        except Exception as e:
-            print(f"ChatterboxVC: Error checking cached VC model device: {e}. Will reload.")
-
-    if current_model is not None and model_device_correct:
-        return current_model
-    else:
-        if current_model is not None and not model_device_correct:
-            print(f"ChatterboxVC: Device mismatch for cached VC model '{model_pack_name}'. Reloading.")
+    cache_key = device_str
+    entry = VC_MODEL_CACHE.get(cache_key)
+    if entry is not None:
+        pack_name, current_model = entry
+        if pack_name == model_pack_name and str(current_model.device) == device_str:
+            return current_model
         else:
-            print(f"ChatterboxVC: VC Model for '{model_pack_name}' on '{device_str}' not in cache. Loading...")
-        VC_MODEL_CACHE[cache_key] = load_chatterbox_vc_model(model_pack_name, device_str)
-        return VC_MODEL_CACHE[cache_key]
+            del VC_MODEL_CACHE[cache_key]
+    else:
+        print(f"ChatterboxVC: VC Model for '{model_pack_name}' on '{device_str}' not in cache. Loading...")
+
+    model = load_chatterbox_vc_model(model_pack_name, device_str)
+    VC_MODEL_CACHE[cache_key] = (model_pack_name, model)
+    return model
 
 
 def set_chatterbox_seed(seed: int):
@@ -216,7 +212,6 @@ def set_chatterbox_seed(seed: int):
     torch.manual_seed(actual_seed_for_torch_random)
     if torch.cuda.is_available():
         torch.cuda.manual_seed(actual_seed_for_torch_random)
-        torch.cuda.manual_seed_all(actual_seed_for_torch_random)
     random.seed(actual_seed_for_torch_random)
     np.random.seed(actual_seed_for_numpy)
     

--- a/nodes.py
+++ b/nodes.py
@@ -31,6 +31,11 @@ class ChatterboxTTSNode:
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
+                "chunk_size": ("INT", {"default": 300, "min": 50, "max": 1000}),
+                "max_retries": ("INT", {"default": 1, "min": 0, "max": 5}),
+                "top_p": ("FLOAT", {"default": 0.8, "min": 0.1, "max": 1.0, "step": 0.05}),
+                "repetition_penalty": ("FLOAT", {"default": 2.0, "min": 1.0, "max": 4.0, "step": 0.1}),
+                "min_p": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 0.5, "step": 0.05}),
             },
             "optional": {
                 "audio_prompt": ("AUDIO",),
@@ -43,7 +48,22 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(
+        self,
+        model_pack_name,
+        text,
+        exaggeration,
+        temperature,
+        cfg_weight,
+        seed,
+        device,
+        chunk_size,
+        max_retries,
+        top_p,
+        repetition_penalty,
+        min_p,
+        audio_prompt=None,
+    ):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -91,9 +111,14 @@ class ChatterboxTTSNode:
                 text,
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
+                cfg_weight=cfg_weight,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                chunk_size=chunk_size,
+                max_retries=max_retries,
+                min_p=min_p,
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -6,6 +6,7 @@ import perth
 import torch.nn.functional as F
 import gc
 from huggingface_hub import hf_hub_download
+from safetensors.torch import load_file
 
 from .models.t3 import T3
 from .models.s3tokenizer import S3_SR, drop_invalid_tokens
@@ -51,10 +52,18 @@ class Conditionals:
     gen: dict
 
     def to(self, device):
-        self.t3 = self.t3.to(device=device)
+        # Move all tensors in the dataclass individually to avoid issues
+        moved = {}
+        for k, v in self.t3.__dict__.items():
+            if torch.is_tensor(v):
+                moved[k] = v.to(device)
+            else:
+                moved[k] = v
+        self.t3 = T3Cond(**moved)
+
         for k, v in self.gen.items():
             if torch.is_tensor(v):
-                self.gen[k] = v.to(device=device)
+                self.gen[k] = v.to(device)
         return self
 
     def save(self, fpath: Path):
@@ -84,19 +93,21 @@ class ChatterboxTTS:
     def from_local(cls, ckpt_dir, device) -> 'ChatterboxTTS':
         ckpt_dir = Path(ckpt_dir)
 
+        map_loc = "cpu" if device in {"cpu", "mps"} else None
+
         ve = VoiceEncoder()
-        ve.load_state_dict(torch.load(ckpt_dir / "ve.pt"))
+        ve.load_state_dict(load_file(ckpt_dir / "ve.safetensors", map_location=map_loc))
         ve.to(device).eval()
 
         t3 = T3()
-        t3_state = torch.load(ckpt_dir / "t3_cfg.pt")
+        t3_state = load_file(ckpt_dir / "t3_cfg.safetensors", map_location=map_loc)
         if "model" in t3_state.keys():
             t3_state = t3_state["model"][0]
         t3.load_state_dict(t3_state)
         t3.to(device).eval()
 
         s3gen = S3Gen()
-        s3gen.load_state_dict(torch.load(ckpt_dir / "s3gen.pt"))
+        s3gen.load_state_dict(load_file(ckpt_dir / "s3gen.safetensors", map_location=map_loc), strict=False)
         s3gen.to(device).eval()
 
         tokenizer = EnTokenizer(str(ckpt_dir / "tokenizer.json"))
@@ -109,15 +120,21 @@ class ChatterboxTTS:
 
     @classmethod
     def from_pretrained(cls, device) -> 'ChatterboxTTS':
-        for f in ["ve.pt", "t3_cfg.pt", "s3gen.pt", "tokenizer.json", "conds.pt"]:
+        for f in [
+            "ve.safetensors",
+            "t3_cfg.safetensors",
+            "s3gen.safetensors",
+            "tokenizer.json",
+            "conds.pt",
+        ]:
             hf_hub_download(repo_id=REPO_ID, filename=f)
-        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.pt")).parent, device)
+        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.safetensors")).parent, device)
 
     def prepare_conditionals(self, wav_fpath, exaggeration=0.5):
         s3gen_ref_wav, _ = librosa.load(wav_fpath, sr=S3GEN_SR)
         ref_16k_wav = librosa.resample(s3gen_ref_wav, orig_sr=S3GEN_SR, target_sr=S3_SR)
 
-        s3gen_ref_wav = s3gen_ref_wav[:self.DEC_COND_LEN]
+        s3gen_ref_wav = s3gen_ref_wav[: self.DEC_COND_LEN]
         s3gen_ref_dict = self.s3gen.embed_ref(s3gen_ref_wav, S3GEN_SR, device=self.device)
 
         if plen := self.t3.hp.speech_cond_prompt_len:
@@ -125,17 +142,17 @@ class ChatterboxTTS:
             t3_cond_prompt_tokens, _ = s3_tokzr.forward([ref_16k_wav[:self.ENC_COND_LEN]], max_len=plen)
             t3_cond_prompt_tokens = torch.atleast_2d(t3_cond_prompt_tokens).to(self.device)
 
-        ve_embed = torch.from_numpy(self.ve.embeds_from_wavs([ref_16k_wav], sample_rate=S3_SR))
-        ve_embed = ve_embed.mean(axis=0, keepdim=True).to(self.device)
-
-        self.conds = Conditionals(
-            T3Cond(
-                speaker_emb=ve_embed,
-                cond_prompt_speech_tokens=t3_cond_prompt_tokens,
-                emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device),
-            s3gen_ref_dict,
+        ve_embed = torch.from_numpy(
+            self.ve.embeds_from_wavs([ref_16k_wav[: self.ENC_COND_LEN]], sample_rate=S3_SR)
         )
+        ve_embed = ve_embed.mean(axis=0, keepdim=True)
+
+        t3_cond = T3Cond(
+            speaker_emb=ve_embed,
+            cond_prompt_speech_tokens=t3_cond_prompt_tokens,
+            emotion_adv=exaggeration * torch.ones(1, 1, 1),
+        )
+        self.conds = Conditionals(t3_cond, s3gen_ref_dict).to(self.device)
 
     def _generate_segment(
         self,
@@ -144,6 +161,9 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
     ):
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration)
@@ -152,11 +172,15 @@ class ChatterboxTTS:
 
         if exaggeration != self.conds.t3.emotion_adv[0, 0, 0]:
             _c = self.conds.t3
-            self.conds.t3 = T3Cond(
+            new_t3 = T3Cond(
                 speaker_emb=_c.speaker_emb,
                 cond_prompt_speech_tokens=_c.cond_prompt_speech_tokens,
                 emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device)
+            )
+            moved = {}
+            for k, v in new_t3.__dict__.items():
+                moved[k] = v.to(self.device) if torch.is_tensor(v) else v
+            self.conds.t3 = T3Cond(**moved)
 
         text = punc_norm(text)
         text_tokens = self.tokenizer.text_to_tokens(text).to(self.device)
@@ -173,6 +197,8 @@ class ChatterboxTTS:
                 text_tokens=text_tokens,
                 max_new_tokens=1000,
                 temperature=temperature,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
                 cfg_weight=cfg_weight,
             )[0]
 
@@ -189,11 +215,14 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
         chunk_size: int = 300,
         max_retries: int = 1,
     ):
-        def safe_segment(t):
-            for attempt in range(max_retries + 1):
+        def _safe_generate_segment(t):
+            for _ in range(max_retries + 1):
                 try:
                     return self._generate_segment(
                         t,
@@ -201,6 +230,9 @@ class ChatterboxTTS:
                         exaggeration=exaggeration,
                         cfg_weight=cfg_weight,
                         temperature=temperature,
+                        top_p=top_p,
+                        repetition_penalty=repetition_penalty,
+                        min_p=min_p,
                     )
                 except RuntimeError as e:
                     if "out of memory" in str(e).lower() and torch.cuda.is_available():
@@ -210,11 +242,11 @@ class ChatterboxTTS:
                     raise
 
         if len(text) <= chunk_size:
-            return safe_segment(text)
+            return _safe_generate_segment(text)
 
         segments = []
         for chunk in chunk_text(text, chunk_size):
-            segment = safe_segment(chunk)
+            segment = _safe_generate_segment(chunk)
             segments.append(segment.squeeze(0).cpu().numpy())
 
         merged = splice_audios(segments)

--- a/src/chatterbox/vc.py
+++ b/src/chatterbox/vc.py
@@ -49,7 +49,9 @@ class ChatterboxVC:
 
         # S3Gen weights (safetensors)
         s3gen = S3Gen()
-        s3gen.load_state_dict(load_file(ckpt_dir / "s3gen.safetensors"), strict=False)
+        s3gen.load_state_dict(
+            load_file(ckpt_dir / "s3gen.safetensors", map_location=map_loc), strict=False
+        )
 
         return cls(s3gen, device, ref_dict)
 


### PR DESCRIPTION
## Summary
- move tensor fields manually to device
- load safetensor weights and handle CPU fallback
- restore long‑prompt safety with retries and chunking
- clamp reference waveform lengths
- simplify seed logic and device model cache
- expose generation options in node UI

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6857734379108330bd913ebbfc3d1b8d