### PR TITLE
Improve device handling and long prompt support

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -29,6 +29,11 @@ class ChatterboxTTSNode:
                 "exaggeration": ("FLOAT", {"default": 0.5, "min": 0.25, "max": 2.0, "step": 0.05}),
                 "temperature": ("FLOAT", {"default": 0.8, "min": 0.05, "max": 5.0, "step": 0.05}),
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
+                "top_p": ("FLOAT", {"default": 0.8, "min": 0.1, "max": 1.0, "step": 0.05}),
+                "repetition_penalty": ("FLOAT", {"default": 2.0, "min": 1.0, "max": 5.0, "step": 0.1}),
+                "min_p": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+                "chunk_size": ("INT", {"default": 300, "min": 50, "max": 1000, "step": 10}),
+                "max_retries": ("INT", {"default": 1, "min": 0, "max": 5}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
             },
@@ -43,7 +48,22 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(
+        self,
+        model_pack_name,
+        text,
+        exaggeration,
+        temperature,
+        cfg_weight,
+        top_p,
+        repetition_penalty,
+        min_p,
+        chunk_size,
+        max_retries,
+        seed,
+        device,
+        audio_prompt=None,
+    ):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -91,9 +111,14 @@ class ChatterboxTTSNode:
                 text,
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
+                cfg_weight=cfg_weight,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                min_p=min_p,
+                chunk_size=chunk_size,
+                max_retries=max_retries,
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/audio_editing.py
+++ b/src/chatterbox/audio_editing.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+
+def splice_audios(segments, xfade_ms=40, sr=24000):
+    """Concatenate segments with a short cross‑fade to avoid pops."""
+    if not segments:
+        return np.array([], dtype=np.float32)
+
+    xfade = int(sr * xfade_ms / 1000)
+    output = np.array(segments[0], dtype=np.float32)
+    for seg in segments[1:]:
+        seg = np.array(seg, dtype=np.float32)
+        if xfade > 0 and len(output) > xfade and len(seg) > xfade:
+            fade_out = np.linspace(1.0, 0.0, xfade, dtype=np.float32)
+            fade_in = np.linspace(0.0, 1.0, xfade, dtype=np.float32)
+            cross = output[-xfade:] * fade_out + seg[:xfade] * fade_in
+            output = np.concatenate([output[:-xfade], cross, seg[xfade:]])
+        else:
+            output = np.concatenate([output, seg])
+    return output

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -14,6 +14,7 @@ from .models.tokenizers import EnTokenizer
 from .models.voice_encoder import VoiceEncoder
 from .models.t3.modules.cond_enc import T3Cond
 from .audio_editing import splice_audios
+from safetensors.torch import load_file
 
 
 REPO_ID = "ResembleAI/chatterbox"
@@ -84,58 +85,81 @@ class ChatterboxTTS:
     def from_local(cls, ckpt_dir, device) -> 'ChatterboxTTS':
         ckpt_dir = Path(ckpt_dir)
 
+        map_loc = None if device in {"cuda", "mps"} else torch.device("cpu")
+
         ve = VoiceEncoder()
-        ve.load_state_dict(torch.load(ckpt_dir / "ve.pt"))
+        ve.load_state_dict(load_file(ckpt_dir / "ve.safetensors", map_location=map_loc))
         ve.to(device).eval()
 
         t3 = T3()
-        t3_state = torch.load(ckpt_dir / "t3_cfg.pt")
+        t3_state = load_file(ckpt_dir / "t3_cfg.safetensors", map_location=map_loc)
         if "model" in t3_state.keys():
             t3_state = t3_state["model"][0]
         t3.load_state_dict(t3_state)
         t3.to(device).eval()
 
         s3gen = S3Gen()
-        s3gen.load_state_dict(torch.load(ckpt_dir / "s3gen.pt"))
+        s3gen.load_state_dict(load_file(ckpt_dir / "s3gen.safetensors", map_location=map_loc), strict=False)
         s3gen.to(device).eval()
 
         tokenizer = EnTokenizer(str(ckpt_dir / "tokenizer.json"))
 
         conds = None
         if (builtin_voice := ckpt_dir / "conds.pt").exists():
-            conds = Conditionals.load(builtin_voice).to(device)
+            conds = Conditionals.load(builtin_voice, map_location=map_loc)
+            # move tensors manually
+            for field, val in conds.t3.__dict__.items():
+                if torch.is_tensor(val):
+                    setattr(conds.t3, field, val.to(device))
+            for k, v in conds.gen.items():
+                if torch.is_tensor(v):
+                    conds.gen[k] = v.to(device)
 
         return cls(t3, s3gen, ve, tokenizer, device, conds)
 
     @classmethod
     def from_pretrained(cls, device) -> 'ChatterboxTTS':
-        for f in ["ve.pt", "t3_cfg.pt", "s3gen.pt", "tokenizer.json", "conds.pt"]:
+        for f in [
+            "ve.safetensors",
+            "t3_cfg.safetensors",
+            "s3gen.safetensors",
+            "tokenizer.json",
+            "conds.pt",
+        ]:
             hf_hub_download(repo_id=REPO_ID, filename=f)
-        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.pt")).parent, device)
+        return cls.from_local(Path(hf_hub_download(repo_id=REPO_ID, filename="ve.safetensors")).parent, device)
 
     def prepare_conditionals(self, wav_fpath, exaggeration=0.5):
         s3gen_ref_wav, _ = librosa.load(wav_fpath, sr=S3GEN_SR)
         ref_16k_wav = librosa.resample(s3gen_ref_wav, orig_sr=S3GEN_SR, target_sr=S3_SR)
 
-        s3gen_ref_wav = s3gen_ref_wav[:self.DEC_COND_LEN]
+        s3gen_ref_wav = s3gen_ref_wav[: self.DEC_COND_LEN]
         s3gen_ref_dict = self.s3gen.embed_ref(s3gen_ref_wav, S3GEN_SR, device=self.device)
+        for k, v in s3gen_ref_dict.items():
+            if torch.is_tensor(v) and v.device != self.device:
+                s3gen_ref_dict[k] = v.to(self.device)
 
         if plen := self.t3.hp.speech_cond_prompt_len:
             s3_tokzr = self.s3gen.tokenizer
-            t3_cond_prompt_tokens, _ = s3_tokzr.forward([ref_16k_wav[:self.ENC_COND_LEN]], max_len=plen)
+            t3_cond_prompt_tokens, _ = s3_tokzr.forward([
+                ref_16k_wav[: self.ENC_COND_LEN]
+            ], max_len=plen)
             t3_cond_prompt_tokens = torch.atleast_2d(t3_cond_prompt_tokens).to(self.device)
 
-        ve_embed = torch.from_numpy(self.ve.embeds_from_wavs([ref_16k_wav], sample_rate=S3_SR))
+        ve_embed = torch.from_numpy(
+            self.ve.embeds_from_wavs([ref_16k_wav], sample_rate=S3_SR)
+        )
         ve_embed = ve_embed.mean(axis=0, keepdim=True).to(self.device)
 
-        self.conds = Conditionals(
-            T3Cond(
-                speaker_emb=ve_embed,
-                cond_prompt_speech_tokens=t3_cond_prompt_tokens,
-                emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device),
-            s3gen_ref_dict,
+        t3_cond = T3Cond(
+            speaker_emb=ve_embed,
+            cond_prompt_speech_tokens=t3_cond_prompt_tokens,
+            emotion_adv=exaggeration * torch.ones(1, 1, 1),
         )
+        for field, val in t3_cond.__dict__.items():
+            if torch.is_tensor(val) and val.device != self.device:
+                setattr(t3_cond, field, val.to(self.device))
+        self.conds = Conditionals(t3_cond, s3gen_ref_dict)
 
     def _generate_segment(
         self,
@@ -144,6 +168,9 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
     ):
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration)
@@ -152,11 +179,15 @@ class ChatterboxTTS:
 
         if exaggeration != self.conds.t3.emotion_adv[0, 0, 0]:
             _c = self.conds.t3
-            self.conds.t3 = T3Cond(
+            t3_cond = T3Cond(
                 speaker_emb=_c.speaker_emb,
                 cond_prompt_speech_tokens=_c.cond_prompt_speech_tokens,
                 emotion_adv=exaggeration * torch.ones(1, 1, 1),
-            ).to(self.device)
+            )
+            for field, val in t3_cond.__dict__.items():
+                if torch.is_tensor(val) and val.device != self.device:
+                    setattr(t3_cond, field, val.to(self.device))
+            self.conds.t3 = t3_cond
 
         text = punc_norm(text)
         text_tokens = self.tokenizer.text_to_tokens(text).to(self.device)
@@ -173,6 +204,8 @@ class ChatterboxTTS:
                 text_tokens=text_tokens,
                 max_new_tokens=1000,
                 temperature=temperature,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
                 cfg_weight=cfg_weight,
             )[0]
 
@@ -189,6 +222,9 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        top_p=0.8,
+        repetition_penalty=2.0,
+        min_p=0.0,
         chunk_size: int = 300,
         max_retries: int = 1,
     ):
@@ -201,6 +237,9 @@ class ChatterboxTTS:
                         exaggeration=exaggeration,
                         cfg_weight=cfg_weight,
                         temperature=temperature,
+                        top_p=top_p,
+                        repetition_penalty=repetition_penalty,
+                        min_p=min_p,
                     )
                 except RuntimeError as e:
                     if "out of memory" in str(e).lower() and torch.cuda.is_available():

--- a/src/chatterbox/vc.py
+++ b/src/chatterbox/vc.py
@@ -49,7 +49,9 @@ class ChatterboxVC:
 
         # S3Gen weights (safetensors)
         s3gen = S3Gen()
-        s3gen.load_state_dict(load_file(ckpt_dir / "s3gen.safetensors"), strict=False)
+        s3gen.load_state_dict(
+            load_file(ckpt_dir / "s3gen.safetensors", map_location=map_loc), strict=False
+        )
 
         return cls(s3gen, device, ref_dict)
 


### PR DESCRIPTION
## Summary
- load models from `safetensors` with CPU fallback
- manually move tensors from `T3Cond` and VC ref dicts to the active device
- add cross‑fade `splice_audios` helper
- expose more TTS parameters in the node UI
- keep one model per device and clean up seeding logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857734379108330bd913ebbfc3d1b8d