### PR TITLE
Add segmented TTS generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Custom nodes for ComfyUI that integrate the [Resemble AI Chatterbox](https://git
     *   Synthesize speech from text.
     *   Optional voice cloning using an audio prompt.
     *   Adjustable parameters: exaggeration, temperature, CFG weight, seed.
+    *   Automatically segments long text into 300-character chunks and stitches the generated audio together.
 *   **Chatterbox Voice Conversion Node:**
     *   Convert the voice in a source audio file to sound like a target voice.
     *   Uses a target audio file for voice characteristics or defaults to a built-in voice if no target is provided.


### PR DESCRIPTION
## Summary
- split long text into 300‑character chunks
- generate audio for each chunk and stitch results
- document new long text behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68577fd3fa9483308fc1aad508e1f806