### PR TITLE
Expose chunk size and configurable max_new_tokens

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -29,6 +29,7 @@ class ChatterboxTTSNode:
                 "exaggeration": ("FLOAT", {"default": 0.5, "min": 0.25, "max": 2.0, "step": 0.05}),
                 "temperature": ("FLOAT", {"default": 0.8, "min": 0.05, "max": 5.0, "step": 0.05}),
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
+                "chunk_size": ("INT", {"default": 300, "min": 1, "max": 1000}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
             },
@@ -43,7 +44,7 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, chunk_size, seed, device, audio_prompt=None):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -92,8 +93,9 @@ class ChatterboxTTSNode:
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                cfg_weight=cfg_weight,
+                chunk_size=chunk_size,
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/models/t3/modules/t3_config.py
+++ b/src/chatterbox/models/t3/modules/t3_config.py
@@ -11,6 +11,7 @@ class T3Config:
     stop_speech_token = 6562
     speech_tokens_dict_size = 8194
     max_speech_tokens = 4096
+    max_new_tokens = 1000
 
     llama_config_name = "Llama_520M"
     input_pos_emb = "learned"


### PR DESCRIPTION
## Summary
- allow callers to set `chunk_size` when generating text segments
- expose `chunk_size` parameter in the ComfyUI node
- add `max_new_tokens` to `T3Config` and use it in TTS generation

## Testing
- `python -m py_compile src/chatterbox/tts.py nodes.py modules/chatterbox_handler.py src/chatterbox/models/t3/modules/t3_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68578cacdf3c83308dad4086bdbe396b