### PR TITLE
Add chunk_size option and configurable token limit

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -31,6 +31,7 @@ class ChatterboxTTSNode:
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
+                "chunk_size": ("INT", {"default": 300, "min": 50, "max": 1000, "step": 10}),
             },
             "optional": {
                 "audio_prompt": ("AUDIO",),
@@ -43,7 +44,7 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, chunk_size, audio_prompt=None):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -92,8 +93,9 @@ class ChatterboxTTSNode:
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                cfg_weight=cfg_weight,
+                chunk_size=chunk_size
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/models/t3/modules/t3_config.py
+++ b/src/chatterbox/models/t3/modules/t3_config.py
@@ -11,6 +11,8 @@ class T3Config:
     stop_speech_token = 6562
     speech_tokens_dict_size = 8194
     max_speech_tokens = 4096
+    # Maximum number of speech tokens to generate in inference
+    max_new_tokens = 1000
 
     llama_config_name = "Llama_520M"
     input_pos_emb = "learned"

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -230,6 +230,10 @@ class T3(nn.Module):
         Args:
             text_tokens: a 1D (unbatched) or 2D (batched) tensor.
         """
+        # Use default from hyperparameters if not provided
+        if max_new_tokens is None:
+            max_new_tokens = self.hp.max_new_tokens
+
         # Validate / sanitize inputs
         assert prepend_prompt_speech_tokens is None, "not implemented"
         _ensure_BOT_EOT(text_tokens, self.hp)

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -211,7 +211,7 @@ class ChatterboxTTS:
             speech_tokens = self.t3.inference(
                 t3_cond=self.conds.t3,
                 text_tokens=text_tokens,
-                max_new_tokens=1000,  # TODO: use the value in config
+                max_new_tokens=self.t3.hp.max_new_tokens,
                 temperature=temperature,
                 cfg_weight=cfg_weight,
             )
@@ -233,6 +233,7 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        chunk_size=300,
     ):
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration=exaggeration)
@@ -248,7 +249,7 @@ class ChatterboxTTS:
                 emotion_adv=exaggeration * torch.ones(1, 1, 1),
             ).to(device=self.device)
 
-        segments = split_text_into_chunks(text, 300)
+        segments = split_text_into_chunks(text, chunk_size)
         if not segments:
             return torch.zeros((1, 0))
 


### PR DESCRIPTION
## Summary
- allow overriding text split size with new `chunk_size` argument
- expose `chunk_size` setting in the TTS node
- make maximum generated token count configurable via T3Config
- use the new config value in generation

## Testing
- `pytest -q`
- `python -m py_compile nodes.py src/chatterbox/tts.py src/chatterbox/models/t3/t3.py src/chatterbox/models/t3/modules/t3_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68578cacdf3c83308dad4086bdbe396b