### PR TITLE
Add configurable chunk size and token limit

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -30,6 +30,7 @@ class ChatterboxTTSNode:
                 "temperature": ("FLOAT", {"default": 0.8, "min": 0.05, "max": 5.0, "step": 0.05}),
                 "cfg_weight": ("FLOAT", {"default": 0.5, "min": 0.2, "max": 1.0, "step": 0.05}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
+                "chunk_size": ("INT", {"default": 300, "min": 50, "max": 1000, "step": 10}),
                 "device": (["cuda", "cpu"], {"default": "cuda" if torch.cuda.is_available() else "cpu"}),
             },
             "optional": {
@@ -43,7 +44,18 @@ class ChatterboxTTSNode:
     CATEGORY = "audio/generation"
     OUTPUT_NODE = True 
 
-    def synthesize(self, model_pack_name, text, exaggeration, temperature, cfg_weight, seed, device, audio_prompt=None):
+    def synthesize(
+        self,
+        model_pack_name,
+        text,
+        exaggeration,
+        temperature,
+        cfg_weight,
+        seed,
+        chunk_size=300,
+        device="cuda" if torch.cuda.is_available() else "cpu",
+        audio_prompt=None,
+    ):
         if not text.strip():
             #print("Chatterbox TTS: Empty text provided, returning silent audio.")
             dummy_sr = 24000 
@@ -92,8 +104,9 @@ class ChatterboxTTSNode:
                 audio_prompt_path=audio_prompt_path_temp,
                 exaggeration=exaggeration,
                 temperature=temperature,
-                cfg_weight=cfg_weight
-            ) 
+                cfg_weight=cfg_weight,
+                chunk_size=chunk_size
+            )
         except Exception as e:
             print(f"ChatterboxTTS: Error during TTS generation: {e}")
             dummy_sr = 24000

--- a/src/chatterbox/models/t3/modules/t3_config.py
+++ b/src/chatterbox/models/t3/modules/t3_config.py
@@ -11,6 +11,8 @@ class T3Config:
     stop_speech_token = 6562
     speech_tokens_dict_size = 8194
     max_speech_tokens = 4096
+    # Maximum number of speech tokens to generate in one call
+    max_new_tokens = 1000
 
     llama_config_name = "Llama_520M"
     input_pos_emb = "learned"

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -211,7 +211,7 @@ class ChatterboxTTS:
             speech_tokens = self.t3.inference(
                 t3_cond=self.conds.t3,
                 text_tokens=text_tokens,
-                max_new_tokens=1000,  # TODO: use the value in config
+                max_new_tokens=self.t3.hp.max_new_tokens,
                 temperature=temperature,
                 cfg_weight=cfg_weight,
             )
@@ -233,6 +233,7 @@ class ChatterboxTTS:
         exaggeration=0.5,
         cfg_weight=0.5,
         temperature=0.8,
+        chunk_size=300,
     ):
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration=exaggeration)
@@ -248,7 +249,7 @@ class ChatterboxTTS:
                 emotion_adv=exaggeration * torch.ones(1, 1, 1),
             ).to(device=self.device)
 
-        segments = split_text_into_chunks(text, 300)
+        segments = split_text_into_chunks(text, chunk_size)
         if not segments:
             return torch.zeros((1, 0))
 


### PR DESCRIPTION
## Summary
- make chunk size for text generation configurable
- expose the chunk size setting in the Comfy node
- store max_new_tokens in the T3Config and use it during generation

## Testing
- `python -m py_compile nodes.py src/chatterbox/tts.py src/chatterbox/models/t3/modules/t3_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68578cacdf3c83308dad4086bdbe396b